### PR TITLE
Fixing Circle CI + Docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
  jobs:
   build:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:5.0
+      - image: mcr.microsoft.com/dotnet/sdk:5.0-alpine
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build-env
 WORKDIR /app
 COPY Book-A-Desk.Api/*.fsproj ./Book-A-Desk.Api/
 COPY Book-A-Desk.Domain/*.fsproj ./Book-A-Desk.Domain/
@@ -12,7 +12,7 @@ RUN dotnet publish \
         ./Book-A-Desk.Api
 
 # runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:5.0
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine
 WORKDIR /app
 EXPOSE 80
 COPY --from=build-env /app/out .


### PR DESCRIPTION
There's a certificate issue meaning Docker and CircleCI won't build on the regular 5.0 version. This fixes it.