### PR TITLE
Introduced commands factory to abstract command dependencies ...

### DIFF
--- a/Book-A-Desk.Api.Tests/BookingsTests.fs
+++ b/Book-A-Desk.Api.Tests/BookingsTests.fs
@@ -1,48 +1,57 @@
 ﻿module Book_A_Desk.Api.Tests.BookingsTests
 
-open Book_A_Desk.Domain.Reservation.Commands
 open Newtonsoft.Json
 open System
 open Xunit
+
+open Book_A_Desk.Api
 open Book_A_Desk.Api.Models
-open Book_A_Desk.Domain.Office.Domain
 open Book_A_Desk.Domain
+open Book_A_Desk.Domain.CommandHandler
+open Book_A_Desk.Domain.Reservation.Commands
+open Book_A_Desk.Domain.Office.Domain
 
 let mockEventStore =
     {
         GetEvents = fun _ -> Result.Ok(List.empty)
         AppendEvents = fun _ -> ()
     }
- 
+
 let mockOfficeId =  Guid.NewGuid ()
-    
+
 let mockOffice =
     {
         Id = mockOfficeId |> OfficeId
         City = CityName "SomeCityName"
         BookableDesksPerDay = 32
-    } 
-    
+    }
+
 let mockGetOffices () =
     mockOffice |> List.singleton
 
+let mockReservationCommandFactory : ReservationCommandsFactory =
+    {
+        CreateBookADeskCommand = fun () -> BookADeskReservationCommand.provide mockGetOffices
+    }
+
 [<Fact>]
-let ``GIVEN A Book-A-Desk server, WHEN booking a desk, THEN a desk is booked`` () = async {    
-    use httpClient = TestServer.createAndRun mockEventStore mockGetOffices
-    
-    let booking  = 
+let ``GIVEN A Book-A-Desk server, WHEN booking a desk, THEN a desk is booked`` () = async {
+    let mockApiDependencyFactory = ApiDependencyFactory.provide mockEventStore mockReservationCommandFactory mockGetOffices
+    use httpClient = TestServer.createAndRun mockApiDependencyFactory
+
+    let booking  =
         {
             Office = { Id = mockOfficeId.ToString() }
             Date = DateTime.MaxValue
             User = { Email = "someEmail" }
         } : InputBooking
-    
+
     let serializedBooking = JsonConvert.SerializeObject(booking)
-    
+
     let! result = HttpRequest.postAsync httpClient $"http://localhost:/bookings" serializedBooking
-        
+
     let deserializedResult = JsonConvert.DeserializeObject<Booking>(result)
-    
+
     Assert.Equal(booking.Office.Id, deserializedResult.Office.Id)
     Assert.Equal(booking.Date, deserializedResult.Date)
     Assert.Equal(booking.User.Email, deserializedResult.User.Email)

--- a/Book-A-Desk.Api.Tests/OfficesTests.fs
+++ b/Book-A-Desk.Api.Tests/OfficesTests.fs
@@ -2,14 +2,18 @@
 
 open System
 open System.Text.Json
+
 open Xunit
 
+open Book_A_Desk.Api
 open Book_A_Desk.Domain
+open Book_A_Desk.Domain.CommandHandler
+open Book_A_Desk.Domain.Reservation.Commands
 open Book_A_Desk.Domain.Events
 open Book_A_Desk.Domain.Office.Domain
 open Book_A_Desk.Domain.Reservation
 open Book_A_Desk.Domain.Reservation.Events
-  
+
 let officeId = Guid.NewGuid ()
 let totalDesks = 32
 let mockOffice =
@@ -17,10 +21,15 @@ let mockOffice =
         Id = officeId |> OfficeId
         City = CityName "SomeCityName"
         BookableDesksPerDay = totalDesks
-    } 
-    
+    }
+
 let mockGetOffices () =
     mockOffice |> List.singleton
+
+let mockReservationCommandFactory : ReservationCommandsFactory =
+    {
+        CreateBookADeskCommand = fun () -> BookADeskReservationCommand.provide mockGetOffices
+    }
 
 [<Fact>]
 let ``GIVEN A Book-A-Desk server, WHEN getting the offices endpoint, THEN offices are returned`` () = async {
@@ -29,12 +38,14 @@ let ``GIVEN A Book-A-Desk server, WHEN getting the offices endpoint, THEN office
             GetEvents = fun _ -> failwith "should not be called"
             AppendEvents = fun _ -> failwith "should not be called"
         }
-    use httpClient = TestServer.createAndRun mockEventStore mockGetOffices
+
+    let mockApiDependencyFactory = ApiDependencyFactory.provide mockEventStore mockReservationCommandFactory mockGetOffices
+    use httpClient = TestServer.createAndRun mockApiDependencyFactory
     let! result = HttpRequest.getAsync httpClient "http://localhost/offices"
-    
+
     let deserializeOptions = JsonSerializerOptions(JsonSerializerDefaults.Web)
     let offices = JsonSerializer.Deserialize<Book_A_Desk.Api.Models.Office array>(result, deserializeOptions)
-    
+
     Assert.Equal(1, offices.Length)
     let office = offices.[0]
     let (OfficeId id) = mockOffice.Id
@@ -46,27 +57,27 @@ let ``GIVEN A Book-A-Desk server, WHEN getting the offices endpoint, THEN office
 [<Fact>]
 let ``GIVEN A Book-A-Desk server, WHEN getting the office availability by date, THEN office availability is returned`` () = async {
     let date = DateTime(2021,02,01)
-    let aBooking =            
+    let aBooking =
         {
             ReservationId = ReservationAggregate.Id
             Date = date
             EmailAddress = "anEmail" |> EmailAddress
             OfficeId = officeId |> OfficeId
         } |> DeskBooked |> ReservationEvent
-        
+
     let mockEventStore =
         {
             GetEvents = fun _ -> Ok [aBooking]
             AppendEvents = fun _ -> failwith "should not be called"
-        }  
-    use httpClient = TestServer.createAndRun mockEventStore mockGetOffices
-    
-    
+        }
+    let mockApiDependencyFactory = ApiDependencyFactory.provide mockEventStore mockReservationCommandFactory mockGetOffices
+    use httpClient = TestServer.createAndRun mockApiDependencyFactory
+
     let! result = HttpRequest.getAsync httpClient $"http://localhost/offices/{officeId.ToString()}/availabilities?date={date.ToString()}"
-    
+
     let deserializeOptions = JsonSerializerOptions(JsonSerializerDefaults.Web)
     let officeAvailability = JsonSerializer.Deserialize<Book_A_Desk.Api.Models.OfficeAvailability>(result, deserializeOptions)
-    
+
     let (OfficeId id) = mockOffice.Id
     Assert.Equal(id.ToString(), officeAvailability.Id)
     Assert.Equal(totalDesks, officeAvailability.TotalDesks)

--- a/Book-A-Desk.Api.Tests/TestServer.fs
+++ b/Book-A-Desk.Api.Tests/TestServer.fs
@@ -9,19 +9,19 @@ open Giraffe
 
 open Book_A_Desk.Api
 
-let private configureApp eventStore getOffices (app : IApplicationBuilder) =
-    let routes = Routes.provide eventStore getOffices
+let private configureApp apiDependencyFactory (app : IApplicationBuilder) =
+    let routes = Routes.provide apiDependencyFactory
     app.UseGiraffe routes.HttpHandlers
 
 let private configureServices (services : IServiceCollection) =
     services.AddGiraffe() |> ignore
 
-let createAndRun eventStore getOffices =
+let createAndRun apiDependencyFactory =
     Host.CreateDefaultBuilder()
         .ConfigureWebHostDefaults(
             fun webHostBuilder ->
                 webHostBuilder
-                    .Configure(configureApp eventStore getOffices)
+                    .Configure(configureApp apiDependencyFactory)
                     .ConfigureServices(configureServices)
                     .UseTestServer()
                     |> ignore

--- a/Book-A-Desk.Api/ApiDependencyFactory.fs
+++ b/Book-A-Desk.Api/ApiDependencyFactory.fs
@@ -1,0 +1,29 @@
+namespace Book_A_Desk.Api
+
+type ApiDependencyFactory =
+    {
+        CreateBookingsHttpHandler: unit -> BookingsHttpHandler
+        CreateOfficesHttpHandler: unit -> OfficesHttpHandler
+    }
+
+module ApiDependencyFactory =
+    let provide
+        eventStore
+        reservationCommandsFactory
+        getOffices
+        =
+
+        let createBookingsHttpHandler bearerToken =
+            BookingsHttpHandler.initialize
+                eventStore
+                reservationCommandsFactory
+
+        let createOfficesHttpHandler bearerToken =
+            OfficesHttpHandler.initialize
+                eventStore
+                getOffices
+
+        {
+            CreateBookingsHttpHandler = createBookingsHttpHandler
+            CreateOfficesHttpHandler = createOfficesHttpHandler
+        }

--- a/Book-A-Desk.Api/Book-A-Desk.Api.fsproj
+++ b/Book-A-Desk.Api/Book-A-Desk.Api.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="OfficesHttpHandler.fs" />
     <Compile Include="BookingsHttpHandler.fs" />
     <Compile Include="HttpHandlers.fs" />
+    <Compile Include="ApiDependencyFactory.fs" />
     <Compile Include="Routes.fs" />
     <Compile Include="Program.fs" />
     <Content Include="docs\bookADeskOpenAPISpecification.json" />

--- a/Book-A-Desk.Api/BookingsHttpHandler.fs
+++ b/Book-A-Desk.Api/BookingsHttpHandler.fs
@@ -17,7 +17,7 @@ type BookingsHttpHandler =
     }
 
 module BookingsHttpHandler =
-    let initialize eventStore getOffices =
+    let initialize eventStore reservationCommandsFactory =
 
         let handlePostWith booking = fun next context ->
             task {
@@ -29,13 +29,13 @@ module BookingsHttpHandler =
                     }
 
                 let command = BookADesk cmd
-                let commandHandler = BookADeskCommandHandler.provide eventStore getOffices
+                let commandHandler = ReservationsCommandHandler.provide eventStore reservationCommandsFactory
 
                 let result = commandHandler.Handle command
                 match result with
                 | Ok _ ->
                     let output =
-                        {                            
+                        {
                             Office = { Id = booking.Office.Id }
                             Date = booking.Date
                             User = { Email = booking.User.Email }

--- a/Book-A-Desk.Api/HttpHandlers.fs
+++ b/Book-A-Desk.Api/HttpHandlers.fs
@@ -7,8 +7,8 @@ type HttpHandlers =
     }
 
 module HttpHandlers =
-    let initialize eventStore getOffices =
+    let initialize eventStore reservationCommandsFactory getOffices =
         {
-            Bookings = BookingsHttpHandler.initialize eventStore getOffices
+            Bookings = BookingsHttpHandler.initialize eventStore reservationCommandsFactory
             Offices = OfficesHttpHandler.initialize eventStore getOffices
         }

--- a/Book-A-Desk.Api/Program.fs
+++ b/Book-A-Desk.Api/Program.fs
@@ -1,5 +1,4 @@
 ﻿open Amazon.DynamoDBv2
-open Book_A_Desk.Domain.Office.Domain
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
 open Microsoft.Extensions.Configuration
@@ -9,10 +8,19 @@ open Giraffe
 
 open Book_A_Desk.Api
 open Book_A_Desk.Domain
+open Book_A_Desk.Domain.CommandHandler
+open Book_A_Desk.Domain.Office.Domain
 
 let configureApp (app : IApplicationBuilder) =
     let eventStore = InMemoryEventStore.provide ()
-    let routes = Routes.provide eventStore (fun () -> Offices.All)
+
+    let getAllOffices = (fun () -> Offices.All)
+
+    let reservationCommandsFactory = ReservationCommandsFactory.provide getAllOffices
+
+    let apiDependencyFactory = ApiDependencyFactory.provide eventStore reservationCommandsFactory getAllOffices
+
+    let routes = Routes.provide apiDependencyFactory
     app.UseGiraffe routes.HttpHandlers
 
 let configureServices (services : IServiceCollection) =

--- a/Book-A-Desk.Domain/Book-A-Desk.Domain.fsproj
+++ b/Book-A-Desk.Domain/Book-A-Desk.Domain.fsproj
@@ -19,6 +19,7 @@
         <Compile Include="EventStore.fs" />
         <Compile Include="Domain.Commands.fs" />
         <Compile Include="QueriesHandler.Reservation.fs" />
+        <Compile Include="CommandFactory.Reservation.fs" />
         <Compile Include="CommandHandler.Reservations.fs" />
         <Compile Include="QueriesHandler.Offices.fs" />
     </ItemGroup>

--- a/Book-A-Desk.Domain/CommandFactory.Reservation.fs
+++ b/Book-A-Desk.Domain/CommandFactory.Reservation.fs
@@ -1,0 +1,20 @@
+namespace Book_A_Desk.Domain.CommandHandler
+
+open Book_A_Desk.Domain.Reservation
+open Book_A_Desk.Domain.Reservation.Commands
+
+type ReservationCommandsFactory =
+    {
+        CreateBookADeskCommand: unit -> BookADeskReservationCommand
+        //CreateCancelADeskCommand: unit -> CancelADeskReservationCommand
+    }
+
+module ReservationCommandsFactory =
+    let provide getOffices =
+
+        let createBookADeskCommand () = BookADeskReservationCommand.provide getOffices
+
+        {
+            CreateBookADeskCommand = createBookADeskCommand
+            //CreateCancelADeskCommand = createCreateCancelADeskCommand
+        }

--- a/Book-A-Desk.Domain/CommandHandler.Reservations.fs
+++ b/Book-A-Desk.Domain/CommandHandler.Reservations.fs
@@ -7,13 +7,13 @@ open Book_A_Desk.Domain.Reservation
 open Book_A_Desk.Domain.Reservation.Domain
 open Book_A_Desk.Domain.Reservation.Commands
 
-type BookADeskCommandHandler =
+type ReservationsCommandHandler =
     {
         Handle: ReservationCommand -> Result<unit,string>
     }
 
-module BookADeskCommandHandler =
-   let provide (eventStore:EventStore) getOffices =
+module ReservationsCommandHandler =
+   let provide (eventStore:EventStore) reservationCommandsFactory =
 
        let handle (command : ReservationCommand) =
             let storeEventsForBatch aggregateId events =
@@ -28,14 +28,13 @@ module BookADeskCommandHandler =
                     events
                     |> List.map (function | ReservationEvent event -> event)
                     |> ReservationAggregate.getCurrentStateFrom
-                    |> executeCommandWith cmd                    
+                    |> executeCommandWith cmd
                 return storeEventsForBatch aggregateId commandResult
             }
 
             match command with
             | BookADesk command ->
-                let commandExecutor = // ToDo: use a reservationCommandFactory.CreateBookADeskReservationCommand ()
-                    BookADeskReservationCommand.provide (BookADeskReservationValidator.validateCommand getOffices)
+                let commandExecutor = reservationCommandsFactory.CreateBookADeskCommand ()
                 run commandExecutor.ExecuteWith command ReservationAggregate.Id
 
        {

--- a/Book-A-Desk.Domain/Reservation.Command.BookADesk.fs
+++ b/Book-A-Desk.Domain/Reservation.Command.BookADesk.fs
@@ -9,8 +9,11 @@ type BookADeskReservationCommand =
     }
 
 module BookADeskReservationCommand =
-    let provide validateCommand =
-        let execute (command:BookADesk) =
+    let provide getAllOffices =
+        let validate (command:BookADesk) reservationAggregate  =
+             BookADeskReservationValidator.validateCommand getAllOffices command reservationAggregate
+
+        let execute (command:BookADesk) reservationAggregate =
             {
                 DeskBooked.ReservationId = ReservationAggregate.Id
                 Date = command.Date
@@ -21,9 +24,10 @@ module BookADeskReservationCommand =
             |> List.singleton
 
         let executeWith cmd reservationAggregate =
-            validateCommand cmd reservationAggregate
-            |> Result.map (fun _ -> execute cmd)
-            
+            (validate cmd reservationAggregate)
+            |> Result.map (execute cmd)
+
+
         {
             ExecuteWith = executeWith
         }

--- a/Book-A-Desk.Domain/Reservation.Commands.fs
+++ b/Book-A-Desk.Domain/Reservation.Commands.fs
@@ -15,5 +15,5 @@ type BookADesk =
 
 type ReservationCommand =
     | BookADesk of BookADesk
-//    | UnbookAdesk Of UnbookAdesk
+    //| CancelADesk of CancelADesk
 

--- a/Book-A-desk.Domain.Tests/Reservation.Command.BookADesk.Tests.fs
+++ b/Book-A-desk.Domain.Tests/Reservation.Command.BookADesk.Tests.fs
@@ -9,11 +9,11 @@ open Book_A_Desk.Domain.Office.Domain
 open Book_A_Desk.Domain.Reservation.Commands
 open Book_A_desk.Domain.Tests
 
-let commandIsValid _ _ = Ok ()
+let getAllOffices = fun () ->  Offices.All
 
 [<Fact>]
 let ``GIVEN A Book-A-Desk Reservation command, WHEN executing the command and desks are available, THEN an event should be created`` () =
-    let command = BookADeskReservationCommand.provide commandIsValid
+    let command = BookADeskReservationCommand.provide getAllOffices
 
     let office = Offices.All.[0]
     let bookADesk = {
@@ -22,15 +22,16 @@ let ``GIVEN A Book-A-Desk Reservation command, WHEN executing the command and de
         BookADesk.OfficeId = office.Id
     }
 
+
     let result = command.ExecuteWith bookADesk A.reservationAggregate
     match result with
     | Error _ -> Assert.False(true)
     | Ok events ->
         Assert.True(events.Length > 0)
-        
+
 [<Fact>]
 let ``GIVEN A Book-A-Desk Reservation command, WHEN executing the command and desks are available, THEN the correct event is created`` () =
-    let command = BookADeskReservationCommand.provide commandIsValid
+    let command = BookADeskReservationCommand.provide getAllOffices
 
     let office = Offices.All.[0]
     let bookADesk = {


### PR DESCRIPTION
from handler dependencies.

The orchestration of dependencies is on a higher layer (at application start). The CommandHandler doesn't have to know anymore what dependencies are needed for the commands. ( We can refactor tests for commands and command handlers in the future to test only responsibility, e.g. when testing command handler we need only test that the right command is called while the command itself can be mocked for this test. The same can be done now with commands. 
Note: When testing command execution we test no implicitly the command validation as well.