### PR TITLE
Office: add opening hours description.

### DIFF
--- a/Book-A-Desk.Api/docs/bookADeskOpenAPISpecification.json
+++ b/Book-A-Desk.Api/docs/bookADeskOpenAPISpecification.json
@@ -220,6 +220,14 @@
           },
           "name" : {
             "type": "string"
+          },
+          "openingHours": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string"
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
We need to display the opening hours for an office. So far @marnika and I were discussing to provide a nice data structure to represent the opening hours as slots defined by a weekday and a from and to time. But we also realised that we need to think properly about it. So we thought maybe it's a good idea to start to introduce the concept of opening hours but instead of providing a sufficient structure to represent the slots we just start with a text that we can use to display the opening hours. The same text can then be used in the backend to add the opening hours to the email. Even conceptually it could make sense that a human provides a display text for the opening hours.