### PR TITLE
Retrieve all bookings for a start date

### DIFF
--- a/Book-A-Desk.Api/docs/bookadesk.openapi.yaml
+++ b/Book-A-Desk.Api/docs/bookadesk.openapi.yaml
@@ -44,7 +44,6 @@ paths:
       parameters:
         - in: query
           name: email
-          required: true
           schema:
             type: string
         - in: query

--- a/Book-A-Desk.Domain/QueriesHandler.Reservation.fs
+++ b/Book-A-Desk.Domain/QueriesHandler.Reservation.fs
@@ -25,6 +25,15 @@ module rec ReservationsQueriesHandler =
         let bookings = (ReservationAggregate.getCurrentStateFrom bookingEvents).BookedDesks
         return List.where (fun booking -> booking.EmailAddress = email && booking.Date >= date) bookings
     }
+    
+    let getUsersBookingsStartFrom (bookingEvents : seq<DomainEvent>) (date : DateTime) : Result<Booking list, string> = result {
+        let bookingEvents =
+                bookingEvents
+                |> Seq.map (function | ReservationEvent event -> event)
+        
+        let bookings = (ReservationAggregate.getCurrentStateFrom bookingEvents).BookedDesks
+        return List.where (fun booking -> booking.Date >= date) bookings
+    }
         
     let private isSameDate date1 date2 =
         date1.Day = date2.Day && date1.Month = date2.Month && date1.Year = date2.Year


### PR DESCRIPTION
This PR makes the email parameter optional for the endpoint /bookings so that we can retrieve all bookings for a date.
For example, calling the endpoint "{{base_url}}/bookings?date=01/01/2022" will return all bookings starting from January 01, 2022.
It can be useful to see all the bookings for a specific date.