### PR TITLE
Fixed issue to allow multiple bookings

### DIFF
--- a/Book-A-Desk.Domain/Reservation.Command.BookADesk.fs
+++ b/Book-A-Desk.Domain/Reservation.Command.BookADesk.fs
@@ -1,7 +1,9 @@
 namespace Book_A_Desk.Domain.Reservation.Commands
 
+open System
 open Book_A_Desk.Domain.Errors
 open Book_A_Desk.Domain.Reservation
+open Book_A_Desk.Domain.Reservation.Domain
 open Book_A_Desk.Domain.Reservation.Events
 
 type BookADeskReservationCommand =
@@ -16,7 +18,7 @@ module BookADeskReservationCommand =
 
         let execute (command:BookADesk) reservationAggregate =
             {
-                DeskBooked.ReservationId = ReservationAggregate.Id
+                DeskBooked.ReservationId = Guid.NewGuid() |> ReservationId
                 Date = command.Date
                 EmailAddress = command.EmailAddress
                 OfficeId = command.OfficeId


### PR DESCRIPTION
This PR fixes an issue where all reservations have the same AggregateId so it is not possible now to do multiple bookings on multiple days for a user. Basically, only one booking is allowed now so this PR generates a new AggregateId so that it is possible to book mulitple times (where each reservation has its own Aggregate Id).